### PR TITLE
Fixing kubectl config view changes in 1.13

### DIFF
--- a/scripts/kube_namespace.sh
+++ b/scripts/kube_namespace.sh
@@ -2,7 +2,7 @@
 
 if [[ -n "$(command -v kubectl)" && -n "$(command -v jq)"  ]]; then
     kubecluster=$(kubectl config current-context 2>/dev/null)
-    kubens=$(kubectl config view ${LP_K8S} --output json | jq ".contexts[] | select(.name==\"${kubecluster}\") | .context.namespace" | tr -d '"' || '')
+    kubens=$(kubectl config view --output json | jq ".contexts[] | select(.name==\"${kubecluster}\") | .context.namespace" | tr -d '"' || '')
 else
     kubens=
 fi


### PR DESCRIPTION
I cannot find this specific change in the release notes, but I do see it in the docs. It appears that one can no longer pass in the context to view into `kubectl config view...`: https://kubernetes.io/docs/reference/kubectl/overview/#operations